### PR TITLE
FOH-497: ensure tick and the sequent job access happens on the main serial queue to prevent potential race conditions

### DIFF
--- a/EDQueue.podspec
+++ b/EDQueue.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'EDQueue'
-  s.version      = '0.10.1'
+  s.version      = '0.10.2'
   s.license      = 'MIT'
   s.summary      = 'A persistent background job queue for iOS.'
   s.homepage     = 'https://github.com/greenbits/queue'

--- a/EDQueue/EDQueue.h
+++ b/EDQueue/EDQueue.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2012 Andrew Sliwinski. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 typedef NS_ENUM(NSInteger, EDQueueResult) {
     EDQueueResultSuccess = 0,

--- a/EDQueue/EDQueue.m
+++ b/EDQueue/EDQueue.m
@@ -234,7 +234,10 @@ NSString *const EDQueueDidBecomeFresh = @"EDQueueDidBecomeFresh";
  */
 - (void)tick
 {
-    dispatch_queue_t gcd = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0);
+    // FOH-497: Ensure everything runs on the main serial queue so there is no potential for race
+    // conditions. Also ensures that all DB access, which is using FMBDB's queue for thread safety,
+    // still happens in sequence.
+    dispatch_queue_t gcd = dispatch_get_main_queue();
     dispatch_async(gcd, ^{
         if (self.isRunning && !self.isActive && [self.engine fetchJobCount] > 0) {
             // Start job


### PR DESCRIPTION
Inspired by this: https://github.com/thisandagain/queue/issues/10